### PR TITLE
[self] Bugfix/팀 인원 주간 통계 로직 null 처리 추가

### DIFF
--- a/src/main/java/com/king/app/application/waiting/PartySizeServiceImpl.java
+++ b/src/main/java/com/king/app/application/waiting/PartySizeServiceImpl.java
@@ -27,6 +27,11 @@ public class PartySizeServiceImpl implements PartySizeService {
     public AveragePartySizeResponse getWeekPartySizeAverage(WeekDateTimeDto date) {
         WeekDto initWeek = WeekDto
                 .createInitializedWeekDto(date.getYear(), date.getMonth(), date.getWeek());
+        Double weekPartySize = waitingMapper.getWeekPartySize(initWeek);
+        if (weekPartySize == null) {
+            System.out.println("NPE 발생");
+            return null;
+        }
         Double partySize = Math.ceil(waitingMapper.getWeekPartySize(initWeek) * 10.0) / 10.0;
         return getAveragePartySizeResponse(partySize);
     }

--- a/src/main/java/com/king/app/application/waiting/PartySizeServiceImpl.java
+++ b/src/main/java/com/king/app/application/waiting/PartySizeServiceImpl.java
@@ -32,7 +32,7 @@ public class PartySizeServiceImpl implements PartySizeService {
             System.out.println("NPE 발생");
             return null;
         }
-        Double partySize = Math.ceil(waitingMapper.getWeekPartySize(initWeek) * 10.0) / 10.0;
+        Double partySize = Math.ceil(weekPartySize * 10.0) / 10.0;
         return getAveragePartySizeResponse(partySize);
     }
 


### PR DESCRIPTION
- 원인 
  - 해당 mb query 값이 null일 경우, Math 연산을 수행하지 못하여 NPE 발생
- 해결방안
  - ceil 메서드 내의 getWeekPartySize 메서드 분리 후 null 처리 임시 로직 추가